### PR TITLE
Minimal new tab page

### DIFF
--- a/browser/extensions/newtab/prerendered/activity-stream-debug.html
+++ b/browser/extensions/newtab/prerendered/activity-stream-debug.html
@@ -38,47 +38,9 @@
     />
   </head>
   <body class="activity-stream">
-    <div id="root"></div>
-    <script src="chrome://browser/content/contentSearchUI.js"></script>
-    <script src="chrome://browser/content/contentSearchHandoffUI.js"></script>
-    <script src="chrome://browser/content/contentTheme.js"></script>
-    <script src="chrome://global/content/vendor/react-dev.js"></script>
-    <script src="chrome://global/content/vendor/react-dom-dev.js"></script>
-    <script src="chrome://global/content/vendor/prop-types.js"></script>
-    <script src="chrome://global/content/vendor/redux.js"></script>
-    <script src="chrome://global/content/vendor/react-redux.js"></script>
-    <script src="chrome://global/content/vendor/react-transition-group.js"></script>
-    <script src="resource://newtab/data/content/activity-stream.bundle.js"></script>
-    <script src="resource://newtab/data/content/newtab-render.js"></script>
-    <script
-      async
-      type="module"
-      src="chrome://global/content/elements/moz-toggle.mjs"
-    ></script>
-    <script
-      async
-      type="module"
-      src="chrome://global/content/elements/moz-button.mjs"
-    ></script>
-    <script
-      async
-      type="module"
-      src="chrome://global/content/elements/moz-button-group.mjs"
-    ></script>
-    <script
-      async
-      type="module"
-      src="chrome://global/content/elements/moz-box-button.mjs"
-    ></script>
-    <script
-      async
-      type="module"
-      src="chrome://global/content/elements/moz-message-bar.mjs"
-    ></script>
-    <script
-      async
-      type="module"
-      src="chrome://global/content/elements/moz-radio-group.mjs"
-    ></script>
+    <div id="root" style="text-align:center;margin-top:20vh;">
+      <h1>Welcome to BrowserX — Built for Agents, Not Humans</h1>
+      <button id="create-agent">Create Agent</button>
+    </div>
   </body>
 </html>

--- a/browser/extensions/newtab/prerendered/activity-stream-noscripts.html
+++ b/browser/extensions/newtab/prerendered/activity-stream-noscripts.html
@@ -38,36 +38,9 @@
     />
   </head>
   <body class="activity-stream">
-    <div id="root"></div>
-    <script
-      async
-      type="module"
-      src="chrome://global/content/elements/moz-toggle.mjs"
-    ></script>
-    <script
-      async
-      type="module"
-      src="chrome://global/content/elements/moz-button.mjs"
-    ></script>
-    <script
-      async
-      type="module"
-      src="chrome://global/content/elements/moz-button-group.mjs"
-    ></script>
-    <script
-      async
-      type="module"
-      src="chrome://global/content/elements/moz-box-button.mjs"
-    ></script>
-    <script
-      async
-      type="module"
-      src="chrome://global/content/elements/moz-message-bar.mjs"
-    ></script>
-    <script
-      async
-      type="module"
-      src="chrome://global/content/elements/moz-radio-group.mjs"
-    ></script>
+    <div id="root" style="text-align:center;margin-top:20vh;">
+      <h1>Welcome to BrowserX — Built for Agents, Not Humans</h1>
+      <button id="create-agent">Create Agent</button>
+    </div>
   </body>
 </html>

--- a/browser/extensions/newtab/prerendered/activity-stream.html
+++ b/browser/extensions/newtab/prerendered/activity-stream.html
@@ -38,47 +38,9 @@
     />
   </head>
   <body class="activity-stream">
-    <div id="root"></div>
-    <script src="chrome://browser/content/contentSearchUI.js"></script>
-    <script src="chrome://browser/content/contentSearchHandoffUI.js"></script>
-    <script src="chrome://browser/content/contentTheme.js"></script>
-    <script src="chrome://global/content/vendor/react.js"></script>
-    <script src="chrome://global/content/vendor/react-dom.js"></script>
-    <script src="chrome://global/content/vendor/prop-types.js"></script>
-    <script src="chrome://global/content/vendor/redux.js"></script>
-    <script src="chrome://global/content/vendor/react-redux.js"></script>
-    <script src="chrome://global/content/vendor/react-transition-group.js"></script>
-    <script src="resource://newtab/data/content/activity-stream.bundle.js"></script>
-    <script src="resource://newtab/data/content/newtab-render.js"></script>
-    <script
-      async
-      type="module"
-      src="chrome://global/content/elements/moz-toggle.mjs"
-    ></script>
-    <script
-      async
-      type="module"
-      src="chrome://global/content/elements/moz-button.mjs"
-    ></script>
-    <script
-      async
-      type="module"
-      src="chrome://global/content/elements/moz-button-group.mjs"
-    ></script>
-    <script
-      async
-      type="module"
-      src="chrome://global/content/elements/moz-box-button.mjs"
-    ></script>
-    <script
-      async
-      type="module"
-      src="chrome://global/content/elements/moz-message-bar.mjs"
-    ></script>
-    <script
-      async
-      type="module"
-      src="chrome://global/content/elements/moz-radio-group.mjs"
-    ></script>
+    <div id="root" style="text-align:center;margin-top:20vh;">
+      <h1>Welcome to BrowserX — Built for Agents, Not Humans</h1>
+      <button id="create-agent">Create Agent</button>
+    </div>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- replace default new tab HTML with minimal page
- show a welcome header and "Create Agent" button

## Testing
- `npm install`
- `npm test` *(fails: Cannot find the Firefox binary)*

------
https://chatgpt.com/codex/tasks/task_e_6849462705c08321afdbf7549624818e